### PR TITLE
Add PHP CS Fixer and Rector configuration files

### DIFF
--- a/.github/workflows/cs-fix-rector.yml
+++ b/.github/workflows/cs-fix-rector.yml
@@ -1,0 +1,47 @@
+name: Coding Standards
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  cs-fix-rector:
+    name: PHP CS Fixer & Rector
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('''**/composer.lock''') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Run PHP CS Fixer
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff
+
+      - name: Run Rector
+        run: vendor/bin/rector process --dry-run

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,54 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->ignoreDotFiles(false)
+    ->ignoreVCS(true)
+    ->exclude([
+        'runtime',
+        'vendor',
+        'public/assets',
+        'public/dist',
+    ])
+    ->in([
+        __DIR__ . '/config',
+        __DIR__ . '/migrations',
+        __DIR__ . '/public',
+        __DIR__ . '/resources',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+        __DIR__ . '/views',
+    ]);
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setFinder($finder)
+    ->setRules([
+        '@PhpCsFixer' => true,
+        '@PhpCsFixer:risky' => true,
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'binary_operator_spaces' => [
+            'default' => 'align_single_space_minimal',
+        ],
+        'cast_spaces' => ['space' => 'none'],
+        'concat_space' => ['spacing' => 'one'],
+        'declare_strict_types' => true,
+        'global_namespace_import' => [
+            'import_classes' => true,
+            'import_constants' => true,
+            'import_functions' => true,
+        ],
+        'native_function_invocation' => [
+            'include' => ['@compiler_optimized'],
+        ],
+        'no_superfluous_phpdoc_tags' => [
+            'allow_mixed' => true,
+        ],
+        'phpdoc_align' => [
+            'align' => 'vertical',
+        ],
+        'phpdoc_to_comment' => false,
+        'return_type_declaration' => ['space_before' => 'one'],
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'types_spaces' => ['space' => 'single'],
+    ]);

--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
         "zircote/swagger-php": "^4.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.64",
         "codeception/c3": "^2.6",
         "codeception/codeception": "^5.0",
         "codeception/lib-innerbrowser": "^3.1",
@@ -97,6 +98,7 @@
         "phpunit/phpunit": "^9.5",
         "roave/infection-static-analysis-plugin": "^1.16",
         "roave/security-advisories": "dev-latest",
+        "rector/rector": "^1.0",
         "spatie/phpunit-watcher": "^1.23",
         "vimeo/psalm": "^4.18",
         "yiisoft/json": "^1.0",

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Set\CodeQualitySetList;
+use Rector\CodingStyle\Set\CodingStyleSetList;
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Set\DeadCodeSetList;
+use Rector\Naming\Set\NamingSetList;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/config',
+        __DIR__ . '/migrations',
+        __DIR__ . '/public',
+        __DIR__ . '/resources',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+        __DIR__ . '/views',
+    ]);
+
+    $rectorConfig->skip([
+        __DIR__ . '/runtime',
+        __DIR__ . '/vendor',
+        '*/var/*',
+        '*/cache/*',
+    ]);
+
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_83,
+        CodeQualitySetList::CODE_QUALITY,
+        CodingStyleSetList::SPACES,
+        DeadCodeSetList::DEAD_CODE,
+        NamingSetList::PSR_4,
+        PHPUnitSetList::PHPUNIT_100,
+    ]);
+};


### PR DESCRIPTION
## Summary
- add project-level PHP CS Fixer configuration covering the main source and resource directories
- add Rector configuration with relevant paths and skip rules
- declare php-cs-fixer and rector as development dependencies so the coding standards workflow can install them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d68e8f7f3c8323b25259d098aaef9f